### PR TITLE
Add setup script for dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ desktop/   - Electron wrapper
 
 ## Usage
 
-Because the environment does not allow installing dependencies automatically, you must run `npm install` in each folder with internet access enabled. Then start the backend and frontend separately:
+Run `./setup.sh` with internet access to install dependencies for each folder. Then start the backend and frontend separately:
 
 ```
 cd backend && npm start

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Setup script for Expense Tracker Desktop App
+# This script installs npm dependencies for the backend, frontend, and desktop directories.
+# Run this script with internet access enabled.
+
+set -e
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+declare -a modules=("backend" "frontend" "desktop")
+
+for dir in "${modules[@]}"; do
+  echo "Installing dependencies in $dir..."
+  (cd "$BASE_DIR/$dir" && npm install)
+  echo "Finished installing $dir"
+done
+
+echo "All dependencies installed."


### PR DESCRIPTION
## Summary
- add `setup.sh` to install dependencies in backend, frontend and desktop
- update README usage instructions to mention the setup script

## Testing
- `bash -n setup.sh`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68747869c2508323b5bf5e9d6896e773