### PR TITLE
Implement expense tracking logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Expense Tracker Desktop App
 
-This repo contains a minimal example of a desktop expense tracker built with React, Express, SQLite and Electron.
+This repo contains a simple desktop expense tracker built with React, Express, SQLite and Electron.
+The application allows you to record expenses and credits, maintain running account balances and generate reports.
+
+## Features
+
+- **Login** page for authentication.
+- **Add/Update Expense** form for recording credit or debit transactions.
+- Running balances for Bank, Chase and Discover accounts along with overall total.
+- **Summary** page showing a pie chart of spending grouped by month, mode or type.
+- **Reports** page to download monthly PDF reports which also display total credit and debit for the selected month.
 
 ## Structure
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -73,23 +73,76 @@ app.delete('/expenses/:id', (req, res) => {
   });
 });
 
-app.get('/summary/:type', (req, res) => {
-  const type = req.params.type; // month|mode|type
+app.get('/summary/:group', (req, res) => {
+  const group = req.params.group; // month|mode|type
   db.all('SELECT * FROM expenses', (err, rows) => {
-    res.json(rows);
+    if (err) return res.status(500).send();
+    const result = {};
+    rows.forEach((row) => {
+      let key;
+      if (group === 'month') {
+        key = row.date?.substring(0, 7) || 'Unknown';
+      } else if (group === 'type') {
+        key = row.type;
+      } else if (group === 'mode') {
+        key = row.mode;
+      } else {
+        key = 'Other';
+      }
+      const sign = row.transType === 'Credit' ? 1 : -1;
+      result[key] = (result[key] || 0) + sign * parseFloat(row.amount || 0);
+    });
+    const data = Object.entries(result).map(([name, value]) => ({ name, value }));
+    res.json(data);
   });
 });
 
 app.get('/report/:month', (req, res) => {
-  const doc = new PDFDocument();
-  const chunks = [];
-  doc.on('data', chunk => chunks.push(chunk));
-  doc.on('end', () => {
-    res.setHeader('Content-Type', 'application/pdf');
-    res.send(Buffer.concat(chunks));
+  const month = req.params.month; // format YYYY-MM
+  db.all('SELECT * FROM expenses WHERE date LIKE ?', [`${month}-%`], (err, rows) => {
+    if (err) return res.status(500).send();
+
+    const doc = new PDFDocument();
+    const chunks = [];
+    doc.on('data', (chunk) => chunks.push(chunk));
+    doc.on('end', () => {
+      res.setHeader('Content-Type', 'application/pdf');
+      res.send(Buffer.concat(chunks));
+    });
+
+    let totalCredit = 0;
+    let totalDebit = 0;
+    doc.fontSize(18).text(`Report for ${month}`, { align: 'center' });
+    doc.moveDown();
+    rows.forEach((row, idx) => {
+      doc.fontSize(12).text(
+        `${idx + 1}. ${row.date} - ${row.item} - ${row.transType} $${row.amount}`
+      );
+      if (row.transType === 'Credit') {
+        totalCredit += parseFloat(row.amount);
+      } else {
+        totalDebit += parseFloat(row.amount);
+      }
+    });
+    doc.moveDown();
+    doc.text(`Total Credit: ${totalCredit.toFixed(2)}`);
+    doc.text(`Total Debit: ${totalDebit.toFixed(2)}`);
+    doc.end();
   });
-  doc.text('Monthly Report');
-  doc.end();
+});
+
+app.get('/reportSummary/:month', (req, res) => {
+  const month = req.params.month;
+  db.all('SELECT * FROM expenses WHERE date LIKE ?', [`${month}-%`], (err, rows) => {
+    if (err) return res.status(500).send();
+    let totalCredit = 0;
+    let totalDebit = 0;
+    rows.forEach((row) => {
+      if (row.transType === 'Credit') totalCredit += parseFloat(row.amount);
+      else totalDebit += parseFloat(row.amount);
+    });
+    res.json({ totalCredit, totalDebit });
+  });
 });
 
 app.listen(port, () => console.log(`Server running on ${port}`));

--- a/frontend/src/components/Reports.jsx
+++ b/frontend/src/components/Reports.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 export default function Reports() {
   const [month, setMonth] = useState('');
+  const [summary, setSummary] = useState({ totalCredit: 0, totalDebit: 0 });
 
   const download = async () => {
     const res = await fetch(`http://localhost:3001/report/${month}`);
@@ -14,11 +15,31 @@ export default function Reports() {
     window.URL.revokeObjectURL(url);
   };
 
+  const fetchSummary = async (m) => {
+    if (!m) return;
+    const res = await fetch(`http://localhost:3001/reportSummary/${m}`);
+    if (res.ok) {
+      const json = await res.json();
+      setSummary(json);
+    }
+  };
+
   return (
     <div>
       <h2>Reports</h2>
-      <input type="month" value={month} onChange={e => setMonth(e.target.value)} />
+      <input
+        type="month"
+        value={month}
+        onChange={(e) => {
+          setMonth(e.target.value);
+          fetchSummary(e.target.value);
+        }}
+      />
       <button onClick={download}>Download PDF</button>
+      <div>
+        <p>Total Credit: {summary.totalCredit.toFixed(2)}</p>
+        <p>Total Debit: {summary.totalDebit.toFixed(2)}</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- flesh out README with project features
- compute account balances on the Add/Update expense page
- summarize data server-side for pie charts
- generate PDF reports with totals
- provide report summary API and show totals on Reports page

## Testing
- `./setup.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874799e20e08323aa0ada7445e9dece